### PR TITLE
Fix TestHnswByteVectorGraph.testSortedAndUnsortedIndicesReturnSameResults

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -345,7 +345,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         for (int i = 0; i < 10; i++) {
           // ask to explore a lot of candidates to ensure the same returned hits,
           // as graphs of 2 indices are organized differently
-          Query query = knnQuery("vector", randomVector(dim), 60);
+          Query query = knnQuery("vector", randomVector(dim), 80);
           int searchSize = 5;
           List<String> ids1 = new ArrayList<>(searchSize);
           List<Integer> docs1 = new ArrayList<>(searchSize);


### PR DESCRIPTION
## Closes https://github.com/apache/lucene/issues/13210

### Description

The following test failed as it produced two different lists of ids for a sorted and unsorted HNSW byte vector graph:

`gradlew test --tests TestHnswByteVectorGraph.testSortedAndUnsortedIndicesReturnSameResults -Dtests.seed=B41BEC5619361A16 -Dtests.locale=hi-IN -Dtests.timezone=Atlantic/Stanley -Dtests.asserts=true -Dtests.file.encoding=UTF-8` 

Considering that the graphs of 2 indices are organized differently we need to explore a lot of candidates (`k`). Increasing `k` from `60` to `80` fixes the test.
